### PR TITLE
Fix products display issue

### DIFF
--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -151,7 +151,7 @@ const Admin = () => {
         
         if (productsResponse.ok) {
           const productsData = await productsResponse.json();
-          setProducts(productsData.data?.products || []);
+          setProducts(productsData.data || []);
         }
 
         // Fetch orders


### PR DESCRIPTION
Fix: Correctly parse product data in Admin page to display products.

The frontend was expecting `productsData.data.products` but the backend was returning the product array directly as `productsData.data`, causing products not to render. This change aligns the frontend parsing with the backend's response structure.